### PR TITLE
PlayFramework + VueJs integration

### DIFF
--- a/content/components-and-libraries/integrations.md
+++ b/content/components-and-libraries/integrations.md
@@ -67,6 +67,7 @@ Integrate with services or other frameworks
 - [ionic-vue](https://github.com/ModusCreateOrg/ionic-vue) - Vue.js integration for Ionic v4
 - [vue-0xcert](https://github.com/0xcert/framework/tree/master/packages/0xcert-vue-plugin) - Vue.js integration for 0xcert Framework - an open-source library that provides tools for building powerful decentralized applications
 - [vue-zdog](https://github.com/AlexandreBonaventure/vue-zdog) Vue wrapper for zDog - a minimalist 3D engine for the browser
+- [vuejs-playframework](https://github.com/SunPj/silhouette-vuejs-app) - PlayFramework + VueJs integration (dev hot reload && prod static assets)
 
 ## Vue CLI 3 Plugins
 


### PR DESCRIPTION
Example shows how PlayFramework works together with VueJs.

On running PlayFramework in DEV mode it proxies Vue dev server so hot reload works well.
On running PlayFramework in PROD mode Vuejs libraries are compiled and added to Play build as static assets.

The advantage of this approach that frontend and backend is fully decoupled.